### PR TITLE
Fixes Java installation in Java feature snippet

### DIFF
--- a/features/java/Dockerfile
+++ b/features/java/Dockerfile
@@ -1,3 +1,4 @@
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 
 RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
 RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
 


### PR DESCRIPTION
Adds a command to the Dockerfile snippet that requests the missing authentication key
necessary to run the installation